### PR TITLE
fix: add live listener for OS theme changes

### DIFF
--- a/src/components/OfferTracker.jsx
+++ b/src/components/OfferTracker.jsx
@@ -21,6 +21,18 @@ const OfferTracker = () => {
 		}
 	}, [darkMode]);
 
+	useEffect(() => {
+		const mediaquery = window.matchMedia('(prefers-color-scheme: dark)');
+		const handler = (e) => {
+			if (!('theme' in localStorage)) {
+				setDarkMode(e.matches);
+			}
+		};
+
+		mediaquery.addEventListener('change', handler);
+		return () => mediaquery.removeEventListener('change', handler);
+	}, []);
+
 	const CATEGORIES = ['All', 'General', 'EWS', 'OBC-NCL', 'SC', 'ST', 'PwD'];
 	const INSTITUTES = ["All", "IISc Bangalore", "IIT Bombay", "IIT Delhi", "IIT Madras", "IIT Kanpur", "IIT Kharagpur",
 		"IIT Roorkee", "IIT Guwahati", "IIT Hyderabad", "IIT BHU", "IIT ISM Dhanbad", "IIT Indore", "IIT Gandhinagar",


### PR DESCRIPTION
## What was done
- Added a `useEffect` with `window.matchMedia('(prefers-color-scheme: dark)')` listener in `OfferTracker.jsx`
- The listener only reacts when no manual theme is saved in `localStorage`
- Once user toggles the theme button, their choice is respected and OS changes are ignored
- Proper event listener cleanup

Closes #14

## Testing
- Change system theme while app is open → UI updates instantly (if no manual toggle done)
- Manual toggle still works and locks the preference